### PR TITLE
Fix service account typo in app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -14,4 +14,4 @@ handlers:
 automatic_scaling:
   max_instances: 5
 
-service_account: ci-deployer@teamsqiuz.iam.gserviceaccount.com
+service_account: ci-deployer@teamsquiz.iam.gserviceaccount.com


### PR DESCRIPTION
## Summary
- correct service account in `app.yaml`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS errors, missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_683fd7fe5350832ca746711974a5fbba