### PR TITLE
Setup Vitest and add utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@fluentui/react-tooltip": "^9.6.6",
@@ -35,6 +36,7 @@
     "tailwindcss": "^4.1.5",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^6.3.4"
+    "vite": "^6.3.4",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/utils/__tests__/getRandomQuestions.test.ts
+++ b/src/utils/__tests__/getRandomQuestions.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { getRandomQuestions } from '../questions';
+import type { Question } from '../../types/types';
+
+const questions: Question[] = [
+  { id: '1', type: 'single', question: 'q1', options: [], answer: [], explanation: '' },
+  { id: '2', type: 'single', question: 'q2', options: [], answer: [], explanation: '' },
+  { id: '3', type: 'single', question: 'q3', options: [], answer: [], explanation: '' },
+];
+
+describe('getRandomQuestions', () => {
+  it('returns the requested number of questions', () => {
+    const res = getRandomQuestions(questions, 2);
+    expect(res).toHaveLength(2);
+    // ensure all items come from source
+    for (const q of res) {
+      expect(questions.map(x => x.id)).toContain(q.id);
+    }
+  });
+
+  it('returns all questions when count is -1', () => {
+    const res = getRandomQuestions(questions, -1);
+    expect(res).toHaveLength(3);
+  });
+
+  it('does not modify the original array', () => {
+    const copy = [...questions];
+    getRandomQuestions(questions, 2);
+    expect(questions).toEqual(copy);
+  });
+});

--- a/src/utils/__tests__/trie.test.ts
+++ b/src/utils/__tests__/trie.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { buildTrie, findMatches, splitText } from '../trie';
+import type { GlossaryEntry } from '../../types/types';
+
+describe('trie utilities', () => {
+  const glossary: GlossaryEntry[] = [
+    { term: 'foo', zh: '', ja: '', en: '', desc: '' },
+    { term: 'bar', zh: '', ja: '', en: '', desc: '' },
+  ];
+  const trie = buildTrie(glossary);
+
+  it('finds matches in text', () => {
+    const matches = findMatches('foo bar baz', trie);
+    expect(matches.map(m => m.term)).toEqual(['foo', 'bar']);
+  });
+
+  it('splits text with matches', () => {
+    const matches = findMatches('foo bar', trie);
+    const segments = splitText('foo bar', matches);
+    expect(segments).toEqual([
+      { text: 'foo', term: 'foo' },
+      { text: ' ', },
+      { text: 'bar', term: 'bar' },
+    ]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,11 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'node',
+  },
 })


### PR DESCRIPTION
## Summary
- add `vitest` and test script
- configure vite for Vitest usage
- test `getRandomQuestions`
- add tests for trie utilities

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8ef7df4832c8e50d1abebc73c19