### PR TITLE
Fix PostCSS Tailwind import

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-import tailwindcss from '@tailwindcss/postcss';
+import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: [tailwindcss, autoprefixer],"@tailwindcss/postcss": {}
+  plugins: [tailwindcss, autoprefixer]
 }


### PR DESCRIPTION
## Summary
- fix import path for Tailwind CSS in `postcss.config.js`
- remove stray configuration

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683fe06813a8832ca8292ef4400ec6a2